### PR TITLE
Feat/Disable ElasticSearch in Management API

### DIFF
--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/MockClient.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/MockClient.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.elasticsearch.client;
+
+import io.gravitee.elasticsearch.exception.ElasticsearchException;
+import io.gravitee.elasticsearch.model.*;
+import io.gravitee.elasticsearch.model.bulk.BulkResponse;
+import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.elasticsearch.version.Version;
+import io.reactivex.Completable;
+import io.reactivex.Single;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Roberto MOZZICATO (roberto.mozzicato at corvallis.it)
+ */
+public class MockClient implements Client {
+
+    @Override
+    public Single<ElasticsearchInfo> getInfo() throws ElasticsearchException {
+        ElasticsearchInfo info = new ElasticsearchInfo();
+        info.setClusterName("MockES");
+        info.setName("MockES");
+        info.setStatus(200);
+        Version v = new Version();
+        v.setNumber("7.4");
+        info.setVersion(v);
+        return Single.just(info);
+    }
+
+    @Override
+    public Single<Health> getClusterHealth() {
+        return Single.just(new Health());
+    }
+
+    @Override
+    public Single<BulkResponse> bulk(final List<io.vertx.core.buffer.Buffer> data) {
+        BulkResponse res = new BulkResponse();
+        res.setTook(10L);
+        res.setErrors(false);
+        res.setItems(new ArrayList<>());
+        return Single.just(res);
+    }
+
+    @Override
+    public Completable putTemplate(String templateName, String template) {
+        return Completable.complete();
+    }
+
+    @Override
+    public Single<CountResponse> count(final String indexes, final String type, final String query) {
+        CountResponse res = new CountResponse();
+        res.setCount(0L);
+        return Single.just(res);
+    }
+
+    @Override
+    public Single<SearchResponse> search(final String indexes, final String type, final String query) {
+        SearchResponse res = new SearchResponse();
+        res.setTook(54L);
+        res.setTimedOut(false);
+        SearchHits hits = new SearchHits();
+        hits.setHits(new ArrayList<SearchHit>());
+        hits.setTotal(new TotalHits(0));
+        res.setSearchHits(hits);
+        return Single.just(res);
+    }
+
+    @Override
+    public Completable putPipeline(String pipelineName, String pipeline) {
+        return Completable.complete();
+    }
+}

--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -84,9 +84,6 @@ public class HttpClient implements Client {
     @Autowired
     private Vertx vertx;
 
-    @Value("${reporters.elasticsearch.enabled:true}")
-    private boolean enabled;
-
     /**
      * Configuration of Elasticsearch (cluster name, addresses, ...)
      */
@@ -118,78 +115,76 @@ public class HttpClient implements Client {
 
     @PostConstruct
     public void initialize() {
-        if (enabled) {
-            final List<Endpoint> endpoints = configuration.getEndpoints();
-            if (!endpoints.isEmpty()) {
-                httpClients = new ArrayList<>(endpoints.size());
-                initializePaths(URI.create(endpoints.get(0).getUrl()));
-                endpoints.forEach(endpoint -> {
-                    final URI elasticEdpt = URI.create(endpoint.getUrl());
+        final List<Endpoint> endpoints = configuration.getEndpoints();
+        if (!endpoints.isEmpty()) {
+            httpClients = new ArrayList<>(endpoints.size());
+            initializePaths(URI.create(endpoints.get(0).getUrl()));
+            endpoints.forEach(endpoint -> {
+                final URI elasticEdpt = URI.create(endpoint.getUrl());
 
-                    WebClientOptions options = new WebClientOptions()
-                            .setDefaultHost(elasticEdpt.getHost())
-                            .setDefaultPort(elasticEdpt.getPort() != -1 ? elasticEdpt.getPort() :
-                                    (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme()) ? 443 : 80));
+                WebClientOptions options = new WebClientOptions()
+                        .setDefaultHost(elasticEdpt.getHost())
+                        .setDefaultPort(elasticEdpt.getPort() != -1 ? elasticEdpt.getPort() :
+                                (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme()) ? 443 : 80));
 
+                if (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme())) {
+                    options
+                            .setSsl(true)
+                            .setTrustAll(true);
+
+                    if (this.configuration.getSslConfig() != null) {
+                        options.setKeyCertOptions(this.configuration.getSslConfig().getVertxWebClientSslKeystoreOptions());
+                    }
+                }
+
+                if (configuration.isProxyConfigured()) {
+                    ProxyOptions proxyOptions = new ProxyOptions();
+                    proxyOptions.setType(ProxyType.valueOf(configuration.getProxyType()));
                     if (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme())) {
-                        options
-                                .setSsl(true)
-                                .setTrustAll(true);
+                        proxyOptions.setHost(configuration.getProxyHttpsHost());
+                        proxyOptions.setPort(configuration.getProxyHttpsPort());
+                        proxyOptions.setUsername(configuration.getProxyHttpsUsername());
+                        proxyOptions.setPassword(configuration.getProxyHttpsPassword());
+                    } else {
+                        proxyOptions.setHost(configuration.getProxyHttpHost());
+                        proxyOptions.setPort(configuration.getProxyHttpPort());
+                        proxyOptions.setUsername(configuration.getProxyHttpUsername());
+                        proxyOptions.setPassword(configuration.getProxyHttpPassword());
+                    }
+                    options.setProxyOptions(proxyOptions);
+                }
 
-                        if (this.configuration.getSslConfig() != null) {
-                            options.setKeyCertOptions(this.configuration.getSslConfig().getVertxWebClientSslKeystoreOptions());
-                        }
+                final WebClient httpClient = WebClient.create(vertx, options);
+
+                // Read configuration to authenticate calls to Elasticsearch (basic authentication only)
+                if (this.configuration.getUsername() != null) {
+                    this.authorizationHeader = this.initEncodedAuthorization(this.configuration.getUsername(),
+                            this.configuration.getPassword());
+                }
+
+                ((WebClientInternal) httpClient.getDelegate()).addInterceptor(context -> {
+                    context.request()
+                            .timeout(configuration.getRequestTimeout())
+                            .putHeader(HttpHeaders.ACCEPT, CONTENT_TYPE)
+                            .putHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
+
+                    // Basic authentication
+                    if (authorizationHeader != null) {
+                        context.request().putHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
                     }
 
-                    if (configuration.isProxyConfigured()) {
-                        ProxyOptions proxyOptions = new ProxyOptions();
-                        proxyOptions.setType(ProxyType.valueOf(configuration.getProxyType()));
-                        if (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme())) {
-                            proxyOptions.setHost(configuration.getProxyHttpsHost());
-                            proxyOptions.setPort(configuration.getProxyHttpsPort());
-                            proxyOptions.setUsername(configuration.getProxyHttpsUsername());
-                            proxyOptions.setPassword(configuration.getProxyHttpsPassword());
-                        } else {
-                            proxyOptions.setHost(configuration.getProxyHttpHost());
-                            proxyOptions.setPort(configuration.getProxyHttpPort());
-                            proxyOptions.setUsername(configuration.getProxyHttpUsername());
-                            proxyOptions.setPassword(configuration.getProxyHttpPassword());
-                        }
-                        options.setProxyOptions(proxyOptions);
-                    }
-
-                    final WebClient httpClient = WebClient.create(vertx, options);
-
-                    // Read configuration to authenticate calls to Elasticsearch (basic authentication only)
-                    if (this.configuration.getUsername() != null) {
-                        this.authorizationHeader = this.initEncodedAuthorization(this.configuration.getUsername(),
-                                this.configuration.getPassword());
-                    }
-
-                    ((WebClientInternal) httpClient.getDelegate()).addInterceptor(context -> {
-                        context.request()
-                                .timeout(configuration.getRequestTimeout())
-                                .putHeader(HttpHeaders.ACCEPT, CONTENT_TYPE)
-                                .putHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
-
-                        // Basic authentication
-                        if (authorizationHeader != null) {
-                            context.request().putHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
-                        }
-
-                        context.next();
-                    });
-
-                    final ElasticsearchClient client = new ElasticsearchClient(httpClient);
-                    httpClients.add(client);
-
-                    // Health check
-                    Observable
-                            .interval(5, TimeUnit.SECONDS)
-                            .flatMapSingle((Function<Long, SingleSource<ElasticsearchInfo>>) aLong -> getInfo(client).onErrorReturnItem(DUMMY_INFO))
-                            .subscribe(info -> client.setAvailable(!info.equals(DUMMY_INFO)));
+                    context.next();
                 });
-            }
+
+                final ElasticsearchClient client = new ElasticsearchClient(httpClient);
+                httpClients.add(client);
+
+                // Health check
+                Observable
+                        .interval(5, TimeUnit.SECONDS)
+                        .flatMapSingle((Function<Long, SingleSource<ElasticsearchInfo>>) aLong -> getInfo(client).onErrorReturnItem(DUMMY_INFO))
+                        .subscribe(info -> client.setAvailable(!info.equals(DUMMY_INFO)));
+            });
         }
     }
 

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/ElasticsearchReporterConfiguration.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/ElasticsearchReporterConfiguration.java
@@ -16,16 +16,21 @@
 package io.gravitee.reporter.elasticsearch.spring;
 
 import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.client.MockClient;
 import io.gravitee.elasticsearch.client.http.*;
 import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
 import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
 import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.vertx.reactivex.core.Vertx;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ElasticsearchReporterConfiguration {
+
+    @Value("${reporters.elasticsearch.enabled:true}")
+    private boolean enabled;
 
     @Bean
     public Vertx vertxRx(io.vertx.core.Vertx vertx) {
@@ -34,6 +39,9 @@ public class ElasticsearchReporterConfiguration {
 
     @Bean
     public Client httpClient(ReporterConfiguration reporterConfiguration) {
+        if(!enabled)
+            return new MockClient();
+
         HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
         clientConfiguration.setEndpoints(reporterConfiguration.getEndpoints());
         clientConfiguration.setUsername(reporterConfiguration.getUsername());

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
@@ -133,6 +133,9 @@ public class RepositoryConfiguration {
 	@Value("${analytics.elasticsearch.http.proxy.https.password:#{null}}")
 	private String proxyHttpsPassword;
 
+	@Value("${analytics.elasticsearch.enabled:true}")
+	private boolean enabled;
+
 	/**
 	 * Elasticsearch endpoints
 	 */

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.spring;
 
 import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.client.MockClient;
 import io.gravitee.elasticsearch.client.http.*;
 import io.gravitee.elasticsearch.exception.ElasticsearchException;
 import io.gravitee.elasticsearch.index.ILMIndexNameGenerator;
@@ -35,6 +36,7 @@ import io.reactivex.Single;
 import io.vertx.reactivex.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -58,7 +60,8 @@ import static java.lang.String.format;
 })
 public class ElasticsearchRepositoryConfiguration {
 
-    private final Logger logger = LoggerFactory.getLogger(ElasticsearchRepositoryConfiguration.class);
+    @Value("${analytics.elasticsearch.enabled:true}")
+    private boolean enabled;
 
     @Bean
     public Vertx vertxRx(io.vertx.core.Vertx vertx) {
@@ -77,6 +80,9 @@ public class ElasticsearchRepositoryConfiguration {
 
     @Bean
     public Client client(RepositoryConfiguration repositoryConfiguration) {
+        if(!enabled)
+            return new MockClient();
+
         HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
         clientConfiguration.setEndpoints(repositoryConfiguration.getEndpoints());
         clientConfiguration.setUsername(repositoryConfiguration.getUsername());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/945

**Description**

This PR adds the capability to disable ElasticSearch repository functionalities in Management Api, by adding a new configuration key 'analytics.elasticsearch.enabled'.
This way it is possible to proper disable ES from both Gateway and Management Api without any log error.
I also moved references to the 'reporters.elasticsearch.enabled' config key from HttpClient to ElasticsearchReporterConfiguration, which should be its proper place.
